### PR TITLE
chore: set wasi-cloud-core to generate sync functions

### DIFF
--- a/crates/wasi-cloud-core/src/capability/mod.rs
+++ b/crates/wasi-cloud-core/src/capability/mod.rs
@@ -30,7 +30,7 @@ mod bindgen {
 
     wasmtime::component::bindgen!({
         world: "interfaces",
-        async: true,
+        async: false,
         with: {
            "wasi:blobstore/container/container": blobstore::Container,
            "wasi:blobstore/container/stream-object-names": blobstore::StreamObjectNames,


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
